### PR TITLE
Potential fix for code scanning alert no. 7: Missing CSRF middleware

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -7,6 +7,7 @@ const helmet = require("helmet");
 const rateLimit = require("express-rate-limit");
 const { body, validationResult } = require("express-validator");
 const cookieParser = require("cookie-parser");
+const lusca = require("lusca");
 const app = express();
 const PORT = process.env.PORT || 5001;
 
@@ -60,6 +61,7 @@ app.use(
 );
 app.use(express.json({ limit: "10kb" })); // Limit body size to prevent DOS
 app.use(cookieParser());
+app.use(lusca.csrf());
 
 // Database Connection
 const MONGO_URI = process.env.MONGO_URI;

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,8 @@
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.3",
     "mongodb": "^7.0.0",
-    "mongoose": "^8.3.2"
+    "mongoose": "^8.3.2",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.0"


### PR DESCRIPTION
Potential fix for [https://github.com/toxicbishop/DSA-with-tsx/security/code-scanning/7](https://github.com/toxicbishop/DSA-with-tsx/security/code-scanning/7)

In general, the problem is fixed by adding a CSRF protection middleware between the session/cookie handling and the application’s state-changing request handlers. For Express apps using cookies, the common approach is to use a well-known CSRF library (for example `csurf` or `lusca.csrf`) to generate and validate a per-session token that must be submitted with mutating requests. The middleware is mounted globally or on specific routes, and front-end code is updated to include the token in each POST/PUT/DELETE request.

For this codebase, the least intrusive fix is to introduce a CSRF middleware right after `cookieParser()` (and after any session middleware, if present elsewhere in the file) to protect all downstream handlers, rather than rewriting individual routes. The static analysis recommendation explicitly mentions `lusca.csrf`, but using `csurf` is also standard; however, to align with the guidance and avoid changing semantics more than necessary, we will wire in `lusca` and its `csrf` middleware. Concretely, in `server/index.js` we will: (1) add an import/require for `lusca` near the top; (2) define a `csrf` middleware using `require('lusca').csrf()`; and (3) call `app.use(csrf())` immediately after `app.use(cookieParser());` so that any routes declared later will be CSRF-protected. This preserves existing behavior except that state-changing requests now require a valid CSRF token; front-end code will need to consume the token from the response (header or body) and send it back with subsequent requests, but such client changes are outside the provided snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
