### PR TITLE
Potential fix for code scanning alert no. 15: Database query built from user-controlled sources

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -483,6 +483,14 @@ app.post(
     try {
       const { type, severity, title, description, name, email } = req.body;
 
+      // Ensure title and email are simple string values to prevent NoSQL injection
+      if (typeof title !== "string" || typeof email !== "string") {
+        return res.status(400).json({
+          success: false,
+          message: "Invalid input type for title or email.",
+        });
+      }
+
       // Duplicate Detection: Reject if same title+email submitted within the last hour
       const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
       const duplicate = await Issue.findOne({


### PR DESCRIPTION
Potential fix for [https://github.com/toxicbishop/DSA-with-tsx/security/code-scanning/15](https://github.com/toxicbishop/DSA-with-tsx/security/code-scanning/15)

In general: For MongoDB/Mongoose queries that use user-controlled fields, ensure those fields are treated strictly as literal values. Either validate that they are primitive types (e.g., strings) before using them, or wrap them in `$eq` so that even if the client sends an object, it’s interpreted as a literal value rather than a query object.

Best fix here without changing functionality: Right before calling `Issue.findOne`, enforce that `title` and `email` are simple strings, rejecting the request with a 400 error if not. This matches the existing error-handling style and preserves semantics for valid clients. Concretely, in `server/index.js` around the `try` block for this endpoint (lines ~484–492), add type checks:

```js
if (typeof title !== "string" || typeof email !== "string") {
  return res.status(400).json({
    success: false,
    message: "Invalid input type.",
  });
}
```

and then keep the existing `Issue.findOne({ title: title, email: email, createdAt: { $gte: oneHourAgo } })` call. No new imports are required; changes are limited to this handler in `server/index.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
