### PR TITLE
Potential fix for code scanning alert no. 18: Database query built from user-controlled sources

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -27,6 +27,49 @@ router.put("/progress", verifyToken, async (req, res) => {
 router.put("/profile", verifyToken, async (req, res) => {
   try {
     const { name, username, age, bio, picture } = req.body;
+
+    // Validate that incoming values are primitives, not objects/query operators
+    if (name !== undefined && typeof name !== "string") {
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid name" });
+    }
+    if (
+      username !== undefined &&
+      username !== null &&
+      typeof username !== "string"
+    ) {
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid username" });
+    }
+    if (age !== undefined) {
+      // allow empty string (handled below), number, or numeric string
+      if (
+        typeof age !== "number" &&
+        typeof age !== "string"
+      ) {
+        return res
+          .status(400)
+          .json({ success: false, message: "Invalid age" });
+      }
+      if (age !== "" && Number.isNaN(Number(age))) {
+        return res
+          .status(400)
+          .json({ success: false, message: "Invalid age" });
+      }
+    }
+    if (bio !== undefined && typeof bio !== "string") {
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid bio" });
+    }
+    if (picture !== undefined && typeof picture !== "string") {
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid picture" });
+    }
+
     const updateData = {};
 
     if (name) updateData.name = name;


### PR DESCRIPTION
Potential fix for [https://github.com/toxicbishop/DSA-with-tsx/security/code-scanning/18](https://github.com/toxicbishop/DSA-with-tsx/security/code-scanning/18)

General approach: Ensure that any value derived from `req.body` and used inside the MongoDB update object is treated strictly as a literal value and not as a query or operator object. The two standard strategies are (1) restructuring the update to wrap user values in `$eq`, or (2) validating that the user values are primitive types (string/number/boolean/null) and not objects/arrays/functions before using them in the update.

Best specific fix here: Keep the current behavior (updating only the allowed fields) but add strict type checks so that `name`, `username`, `age`, `bio`, and `picture` are only used if they are either `undefined` or of an expected primitive type. Reject the request with `400` if any of these fields is an object or array, thus preventing malicious query objects from reaching `findByIdAndUpdate`. This matches the “Alternatively check that the user input is a literal value and not a query object before using it” pattern from the background.

Concretely, in `server/routes/users.js` inside the `/profile` handler:

- After destructuring `{ name, username, age, bio, picture } = req.body`, add validation code:
  - If `name` is provided but not a string, return 400.
  - If `username` is provided but not a string (and not `null`/empty string if that’s allowed), return 400.
  - If `age` is provided but not a number or numeric string, return 400.
  - If `bio` is provided but not a string, return 400.
  - If `picture` is provided but not a string, return 400.
- This ensures that none of these can be objects like `{ $gt: "" }` or arrays.
- Then keep the existing logic for building `updateData` and calling `User.findByIdAndUpdate`.

No new helper methods or imports are strictly required; we can use simple `typeof` checks and `Number.isNaN` / `isNaN` for age.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
