### PR TITLE
fix: patch mongoose NoSQL injection (CVE) and ip-address XSS vulnerabilities

### DIFF
--- a/server/executor/package-lock.json
+++ b/server/executor/package-lock.json
@@ -454,9 +454,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/server/executor/package.json
+++ b/server/executor/package.json
@@ -10,5 +10,8 @@
   "dependencies": {
     "express": "^4.19.2",
     "express-rate-limit": "^8.2.2"
+  },
+  "overrides": {
+    "ip-address": ">=10.1.1"
   }
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -25,7 +25,7 @@
         "lodash": "^4.18.0",
         "lusca": "^1.7.0",
         "mongodb": "^7.0.0",
-        "mongoose": "^8.3.2",
+        "mongoose": "^8.22.1",
         "multer": "^2.1.1",
         "nodemailer": "^8.0.5"
       },
@@ -3561,9 +3561,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4886,9 +4886,9 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.21.0.tgz",
-      "integrity": "sha512-dW2U01gN8EVQT5KAO5AkzjbqWc8A/CsEq15jOzq/M9ISpy8jw3iq7W9ZP135h9zykFOMt3AMxq4+anvt2YNJgw==",
+      "version": "8.23.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.23.1.tgz",
+      "integrity": "sha512-gHSPD8qEwRmiXapK17hEnFWZdcFENMegHTcw5XIIg2+7R8eXQvdwSiMpD/A2oG8tKzFLLHyRXd8/eaDPAVwZgQ==",
       "license": "MIT",
       "dependencies": {
         "bson": "^6.10.4",

--- a/server/package.json
+++ b/server/package.json
@@ -27,7 +27,7 @@
     "lodash": "^4.18.0",
     "lusca": "^1.7.0",
     "mongodb": "^7.0.0",
-    "mongoose": "^8.3.2",
+    "mongoose": "^8.22.1",
     "multer": "^2.1.1",
     "nodemailer": "^8.0.5"
   },
@@ -40,6 +40,7 @@
     "testMatch": ["<rootDir>/__tests__/**/*.test.js"]
   },
   "overrides": {
-    "minimatch": "^10.2.2"
+    "minimatch": "^10.2.2",
+    "ip-address": ">=10.1.1"
   }
 }


### PR DESCRIPTION
## Security Vulnerabilities Resolved

Both reported vulnerabilities have been fully resolved.

### Applied Security Patches

| Alert | Package | Before | After | Location |
|---|---|---|---|---|
| #40 — NoSQL Injection via `$nor` | `mongoose` | `8.3.2` | `8.23.1` | `server/package.json` |
| #39 — XSS in `Address6` methods | `ip-address` | `10.1.0` | `10.2.0` | `server/executor/package.json` (override) |

---

## Changes Made

- Updated `mongoose` in `server/package.json`
  - `^8.3.2` → `^8.22.1`

- Added `ip-address` override in:
  - `server/package.json`

- Added `overrides` block in:
  - `server/executor/package.json`
  - Enforces `ip-address >= 10.1.1`

- Regenerated both lockfiles using:
  - `npm install`

---

## Verification

- `npm audit` reports `0 vulnerabilities` in both packages
- Dependency overrides successfully applied
- Lockfiles updated and committed