### PR TITLE
chore(deps): upgrade fast-uri to fix security vulnerabilities #43

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2958,9 +2958,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "overrides": {
     "minimatch": "^10.2.2",
     "cookie": "^0.7.0",
-    "postcss": "^8.5.10"
+    "postcss": "^8.5.10",
+    "fast-uri": "^3.1.2"
   }
 }


### PR DESCRIPTION
# Security Update: Upgrade fast-uri to v3.1.2

## Overview
This PR resolves two security vulnerabilities identified in the fast-uri package. Because the package was a transitive dependency (brought in by ajv), a manual override was applied to the root configuration to force the secure version.

---

## Actions Taken

### 1. Dependency Investigation
* **Command:** npm ls fast-uri
* **Discovery:** Found fast-uri@3.1.0 nested within the dependency tree of ajv@8.18.0.
* **Scope:** Checked root, /server, and /server/executor workspaces.

### 2. Manual Resolution (Overrides)
* **Strategy:** Modified the root package.json to include an overrides block. This ensures that even if sub-dependencies request an older version, npm will install the patched version.
* **Code Change:**
  ```json
  "overrides": {
    "fast-uri": "^3.1.2"
  }